### PR TITLE
Support SUPPRESS_JUNIT variable not existing in build config.

### DIFF
--- a/vars/familyTransformPipeline.groovy
+++ b/vars/familyTransformPipeline.groovy
@@ -335,7 +335,7 @@ def call(body) {
                 script {
                     def relativeDatasetDir = "datasets/${JOB_BASE_NAME}"
                     archiveArtifacts artifacts: "${relativeDatasetDir}/out/*", excludes: "${relativeDatasetDir}/out/**/*.html"
-                    if (!Boolean.parseBoolean(SUPPRESS_JUNIT)) {
+                    if (!Boolean.parseBoolean(env.SUPPRESS_JUNIT)) {
                         junit allowEmptyResults: true, testResults: 'reports/**/*.xml'
                     }
                     publishHTML([


### PR DESCRIPTION
There are currently build problems ongoing as in https://ci.floop.org.uk/job/GSS_data/job/COVID-19/job/NISRA-Weekly-deaths-Year-NI/107/console

It seems to be primarily caused by a slight incorrect use of syntax which causes a build failure when an (optional) environmental variable isn't set. I believe this syntax correction will correct that.

