### PR TITLE
Fixing drafter error untested by integration test.

### DIFF
--- a/src/uk/org/floop/jenkins_pmd/MockDrafter.groovy
+++ b/src/uk/org/floop/jenkins_pmd/MockDrafter.groovy
@@ -34,6 +34,11 @@ class MockDrafter extends AbstractDrafter {
 
     @Override
     Dictionary<String, Object> addData(String draftId, String source, String mimeType, String encoding, String graph) throws DrafterException {
+        // Let's ensure that the file we've been told about actually exists.
+        // This is to ensure we at least test that the path provided to the function is acceptable.
+        if (!(new File(source).exists())) {
+            throw new IllegalArgumentException("File '${source}' does not exist.")
+        }
         [:]
     }
 

--- a/vars/familyTransformPipeline.groovy
+++ b/vars/familyTransformPipeline.groovy
@@ -195,7 +195,7 @@ def call(body) {
                                             echo "Adding ${observations.name}"
                                             drafter.addData(
                                                     id,
-                                                    "out/${observations.name}",
+                                                    "${DATASET_DIR}/out/${observations.name}",
                                                     "text/turtle",
                                                     "UTF-8",
                                                     datasetGraph
@@ -203,7 +203,7 @@ def call(body) {
                                             writeFile(file: "out/${baseName}-ds-prov.ttl", text: util.jobPROV(datasetGraph))
                                             drafter.addData(
                                                     id,
-                                                    "out/${baseName}-ds-prov.ttl",
+                                                    "${DATASET_DIR}/out/${baseName}-ds-prov.ttl",
                                                     "text/turtle",
                                                     "UTF-8",
                                                     datasetGraph
@@ -211,7 +211,7 @@ def call(body) {
                                             echo "Adding metadata."
                                             drafter.addData(
                                                     id,
-                                                    "out/${baseName}.csv-metadata.trig",
+                                                    "${DATASET_DIR}/out/${baseName}.csv-metadata.trig",
                                                     "application/trig",
                                                     "UTF-8",
                                                     metadataGraph
@@ -219,7 +219,7 @@ def call(body) {
                                             writeFile(file: "out/${baseName}-md-prov.ttl", text: util.jobPROV(metadataGraph))
                                             drafter.addData(
                                                     id,
-                                                    "out/${baseName}-md-prov.ttl",
+                                                    "${DATASET_DIR}/out/${baseName}-md-prov.ttl",
                                                     "text/turtle",
                                                     "UTF-8",
                                                     metadataGraph
@@ -232,7 +232,7 @@ def call(body) {
                                         echo "Adding local codelist ${baseName}"
                                         drafter.addData(
                                                 id,
-                                                "out/codelists/${codelist.name}",
+                                                "${DATASET_DIR}/out/codelists/${codelist.name}",
                                                 "text/turtle",
                                                 "UTF-8",
                                                 codelistGraph
@@ -240,7 +240,7 @@ def call(body) {
                                         writeFile(file: "out/codelists/${baseName}-prov.ttl", text: util.jobPROV(codelistGraph))
                                         drafter.addData(
                                                 id,
-                                                "out/codelists/${baseName}-prov.ttl",
+                                                "${DATASET_DIR}/out/codelists/${baseName}-prov.ttl",
                                                 "text/turtle",
                                                 "UTF-8",
                                                 codelistGraph


### PR DESCRIPTION
The drafter needs absolute file paths. This functionality wasn't previously tested by the integration tests. I've added some functionality to ensure the file that we tell the drafter about actually exists.