### PR TITLE
Submit draftset for review even if SPARQL tests fail.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ tasks {
     processIntegrationTestResources {
         dependsOn("resolveIntegrationTestDependencies")
     }
+
+    integrationTest {
+        environment("PMD_DRAFTSET_URI_BASE", "https://staging.gss-data.org.uk/admin/drafts/")
+    }
 }
 
 java {


### PR DESCRIPTION
This will help ensure DMs can more easily trackdown the problem by executing SPARQL against the draftset in PMD.