### PR TITLE
Pass mulitple test directories to one invocation of sparql-test-runner.

### DIFF
--- a/vars/sparqlTests.groovy
+++ b/vars/sparqlTests.groovy
@@ -32,7 +32,7 @@ def test(Map config = null) {
     String TOKEN = drafter.getToken()
     try {
         wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: TOKEN, var: 'TOKEN']]]) {
-            sh "sparql-test-runner ${testDirArgs} -s '${endpoint}?union-with-live=true&timeout=180' -l 10 -k '${TOKEN}' ${fromArgs} -r 'reports/TESTS-${dspath}-${testGroup}.xml'"
+            sh "sparql-test-runner ${testDirArgs} -s '${endpoint}?union-with-live=true&timeout=180' -l 10 -k '${TOKEN}' ${fromArgs} -r 'reports/TESTS-${dspath}.xml'"
         }
     } catch (err) {
         // Ensure we still submit the draftset to editors, so it's still

--- a/vars/sparqlTests.groovy
+++ b/vars/sparqlTests.groovy
@@ -26,13 +26,13 @@ def test(Map config = null) {
         fromGraphs += util.referencedGraphs(pmd, draftId)
     }
     String fromArgs = fromGraphs.unique().collect { '-f ' + it }.join(' ')
+    String testDirArgs = testGroups.collect {
+        '-t /usr/local/tests/' + SparqlTestGroup.toDirectoryName(it)
+    }.join(' ')
     String TOKEN = drafter.getToken()
     try {
         wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: TOKEN, var: 'TOKEN']]]) {
-            for (SparqlTestGroup testGroup in testGroups) {
-                String testDirectoryName = SparqlTestGroup.toDirectoryName(testGroup)
-                sh "sparql-test-runner -t /usr/local/tests/${testDirectoryName} -s '${endpoint}?union-with-live=true&timeout=180' -l 10 -k '${TOKEN}' ${fromArgs} -r 'reports/TESTS-${dspath}-${testGroup}.xml'"
-            }
+            sh "sparql-test-runner ${testDirArgs} -s '${endpoint}?union-with-live=true&timeout=180' -l 10 -k '${TOKEN}' ${fromArgs} -r 'reports/TESTS-${dspath}-${testGroup}.xml'"
         }
     } catch (err) {
         // Ensure we still submit the draftset to editors, so it's still


### PR DESCRIPTION
There are no tests for this as we're not mocking interactions in the pipeline jobs yet.

The functionality has been implemented in `sparql-test-runner`, but we need to update `gdp-sparql-tests` to incorporate them.