### PR TITLE
Attempt to validate codelists as well as the tidy/observations files.

### DIFF
--- a/vars/familyTransformPipeline.groovy
+++ b/vars/familyTransformPipeline.groovy
@@ -81,13 +81,12 @@ def call(body) {
                                 ansiColor('xterm') {
                                     def schemas = []
                                     dir("${DATASET_DIR}") {
-                                        dir("out") {
-                                            for (def schema : findFiles(glob: "*-metadata.json")) {
-                                                schemas.add("${schema.name}")
-                                            }
-                                            for (String schema : schemas) {
-                                                sh "csvlint --no-verbose -s ${schema}"
-                                            }
+                                        for (def schema : findFiles(glob: "codelists/*.csv-metadata.json") +
+                                                        findFiles(glob: "out/*-metadata.json")) {
+                                            schemas.add("${schema.path}")
+                                        }
+                                        for (String schema : schemas) {
+                                            sh "csvlint --no-verbose -s ${schema}"
                                         }
                                     }
                                 }


### PR DESCRIPTION
Ideally the local codelists would be linked up in the main `-metadata.json` file as external tables that we could use for foreign key constraints while validating.

As I can't figure out whether I've got the syntax wrong or it's another bug in `csvlint`, this will have to do.