### PR TITLE
Restrict FROM graphs

### DIFF
--- a/src/uk/org/floop/jenkins_pmd/Job.groovy
+++ b/src/uk/org/floop/jenkins_pmd/Job.groovy
@@ -160,10 +160,6 @@ SELECT DISTINCT ?graph WHERE {
   } UNION {
     ?ds qb:structure/qb:component/qb:componentProperty/qb:codeList ?cs .
     GRAPH ?graph { ?cs a skos:ConceptScheme }
-  } UNION {
-    ?ds qb:structure/qb:component/qb:componentProperty/qb:codeList ?cs.
-    ?concept skos:inScheme ?cs.
-    GRAPH ?graph { ?concept rdfs:label ?conceptLabel. }
   }
 }
 VALUES ( ?ds ) {

--- a/src/uk/org/floop/jenkins_pmd/Job.groovy
+++ b/src/uk/org/floop/jenkins_pmd/Job.groovy
@@ -160,6 +160,17 @@ SELECT DISTINCT ?graph WHERE {
   } UNION {
     ?ds qb:structure/qb:component/qb:componentProperty/qb:codeList ?cs .
     GRAPH ?graph { ?cs a skos:ConceptScheme }
+  } UNION {
+    ?ds qb:structure/qb:component/qb:componentProperty/qb:codeList ?cs.
+    GRAPH ?own_graph {
+      ?cs a skos:ConceptScheme .
+      FILTER NOT EXISTS {
+        ?any_concept skos:inScheme ?cs ;
+            rdfs:label ?any_label
+      }
+    }
+    ?concept skos:inScheme ?cs.
+    GRAPH ?graph { ?concept rdfs:label ?conceptLabel. }
   }
 }
 VALUES ( ?ds ) {


### PR DESCRIPTION
Assume concept schemes are self-contained, so don't look for concept labels outside of declared concept scheme's graph.

Closes #78 